### PR TITLE
fix: {buffer} type error of nvim_buf_set_keymap

### DIFF
--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -5,4 +5,4 @@
 local nvim_buf_set_keymap = vim.api.nvim_buf_set_keymap
 
 -- follow md links
-nvim_buf_set_keymap('0', 'n', '<cr>', ':lua require("follow-md-links").follow_link()<cr>', {noremap = true, silent = true})
+nvim_buf_set_keymap(0, 'n', '<cr>', ':lua require("follow-md-links").follow_link()<cr>', {noremap = true, silent = true})


### PR DESCRIPTION
```log
E5113: Error while calling lua chunk: .../packer/start/follow-md-links.nvim/ftplugin/markdown.lua:7: Expected Lua number
stack traceback:
        [C]: in function 'nvim_buf_set_keymap'
```