### PR TITLE
Handle path containing URL-encoded space character (%20)

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -71,7 +71,7 @@ local function resolve_link(link)
 	local link_type
 	if link:sub(1, 1) == [[/]] then
 		link_type = "local"
-		return link, link_type
+		return link:gsub("%%20", " "), link_type
 	elseif link:sub(1, 1) == [[~]] then
 		link_type = "local"
 		return os.getenv("HOME") .. [[/]] .. link:sub(2), link_type
@@ -80,7 +80,7 @@ local function resolve_link(link)
 		return link, link_type
 	else
 		link_type = "local"
-		return fn.expand("%:p:h") .. [[/]] .. link, link_type
+		return fn.expand("%:p:h") .. [[/]] .. link:gsub("%%20", " "), link_type
 	end
 end
 

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -71,7 +71,7 @@ local function resolve_link(link)
 	local link_type
 	if link:sub(1, 1) == [[/]] then
 		link_type = "local"
-		return link:gsub("%%20", " "), link_type
+		return vim.fn.resolve(link:gsub("%%20", " ")), link_type
 	elseif link:sub(1, 1) == [[~]] then
 		link_type = "local"
 		return os.getenv("HOME") .. [[/]] .. link:sub(2), link_type
@@ -80,7 +80,7 @@ local function resolve_link(link)
 		return link, link_type
 	else
 		link_type = "local"
-		return fn.expand("%:p:h") .. [[/]] .. link:gsub("%%20", " "), link_type
+		return vim.fn.resolve(fn.expand("%:p:h") .. [[/]] .. link:gsub("%%20", " ")), link_type
 	end
 end
 


### PR DESCRIPTION
Replace `%20` to ` ` (actual space) in the local path in case the path contains spaces in it.

For example, right now the plugin doesn't work if the link looks like
```
[Foo Bar](Foo%20Bar.md)
```
This PR fixes that.