### PR TITLE
updated treesitter.parse_query command

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -20,7 +20,7 @@ local function get_reference_link_destination(link_label)
 	local language_tree = vim.treesitter.get_parser(0)
 	local syntax_tree = language_tree:parse()
 	local root = syntax_tree[1]:root()
-	local parse_query = vim.treesitter.parse_query("markdown", [[
+	local parse_query = vim.treesitter.query.parse("markdown", [[
   (link_reference_definition
     (link_label) @label (#eq? @label "]] .. link_label .. [[")
     (link_destination) @link_destination)


### PR DESCRIPTION
The treesitter.parse_query command is throwing a warning that the command needs to be updated.

I've changed the command to squelch the warning.