### PR TITLE
Filenames with whitespace support

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -25,8 +25,13 @@ local function get_reference_link_destination(link_label)
     (link_label) @label (#eq? @label "]] .. link_label .. [[")
     (link_destination) @link_destination)
   ]])
+	-- Problem with handling whitespace in filenames elegently is with this iter_matches
 	for _, captures, _ in parse_query:iter_matches(root, 0) do
-		return treesitter.get_node_text(captures[2], 0)
+		local node_text = treesitter.get_node_text(captures[2], 0)
+		-- Kludgy method right now is to require that filenames with spaces are wrapped in <>,
+		-- which are stripped out after the matching is complete
+		return string.gsub(node_text, "[<>]", "")
+		--return treesitter.get_node_text(captures[2], 0)
 	end
 end
 

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -20,7 +20,7 @@ local function get_reference_link_destination(link_label)
 	local language_tree = vim.treesitter.get_parser(0)
 	local syntax_tree = language_tree:parse()
 	local root = syntax_tree[1]:root()
-	local parse_query = vim.treesitter.query.parse("markdown", [[
+	local parse_query = vim.treesitter.parse_query("markdown", [[
   (link_reference_definition
     (link_label) @label (#eq? @label "]] .. link_label .. [[")
     (link_destination) @link_destination)

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -20,7 +20,7 @@ local function get_reference_link_destination(link_label)
 	local language_tree = vim.treesitter.get_parser(0)
 	local syntax_tree = language_tree:parse()
 	local root = syntax_tree[1]:root()
-	local parse_query = vim.treesitter.parse_query("markdown", [[
+	local parse_query = vim.treesitter.query.parse("markdown", [[
   (link_reference_definition
     (link_label) @label (#eq? @label "]] .. link_label .. [[")
     (link_destination) @link_destination)


### PR DESCRIPTION
To address issues #3 and #18, I've made a change to allow whitespace in path or filenames in reference links.

To achieve this, the links with whitspace need to be wrapped in `< >`. For example:

```markdown
[ref link 1][1]
[ref link 2][2]

[1]: ./file_without_space.md
[2]. <./file with space.md>
```

The link `./file_without_space.md` should also be written as `<./file_without_space.md>` without an issue. The PR strips the `<>` after the `iter_match` call, which seems to be the source of the problem.