### PR TITLE
Added method to check if we can follow link

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -112,7 +112,20 @@ local function follow_local_link(link)
 	end
 end
 
+local function can_follow_link()
+	-- we can follow link if the current buffer is of type markdown
+	-- otherwise we cannot
+	if vim.bo.filetype == "markdown" then
+		return true
+	end
+	return false
+end
+
 function M.follow_link()
+	if not can_follow_link() then
+		return
+	end
+
 	local link_destination = get_link_destination()
 
 	if link_destination then


### PR DESCRIPTION
Hello, I was getting several errors / crashes with the script when pressing `<cr>` in text-based buffers (like a `.txt` or `.tex` buffer). So I thought of adding a check to confirm that the current buffer is of type `markdown` when `follow_link` is called in order to avoid calling it for non-markdown buffers.

I am an absolute beginner with lua plugins and especially for neovim, so if this is redundant do let me know