### PR TITLE
Fix following the link in the Windows OS

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -9,10 +9,12 @@ local ts_utils = require("nvim-treesitter.ts_utils")
 local query = require("vim.treesitter.query")
 local treesitter = require("vim.treesitter")
 
-local M = {}
+function string:startswith(start)
+    return self:sub(1, #start) == start
+end
 
 local os_name = loop.os_uname().sysname
-local is_windows = os_name == "Windows"
+local is_windows = os_name:startswith("Windows")
 local is_macos = os_name == "Darwin"
 local is_linux = os_name == "Linux"
 
@@ -111,6 +113,8 @@ local function follow_local_link(link)
 		end
 	end
 end
+
+local M = {}
 
 function M.follow_link()
 	local link_destination = get_link_destination()


### PR DESCRIPTION
For some reasons on my machine the `sysname` attribute equals `Windows_NT`.
So in that tiny PR I would like to fix that and make sysname check more extended.