### PR TITLE
Resolve links without .md extension again (fix #26)

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -92,22 +92,17 @@ end
 
 local function follow_local_link(link)
 	local modified_link = nil
-	local line_number = nil
-	if vim.fn.filereadable(link) == 0 then
-		-- attempt to add an extension and open
-		if vim.fn.filereadable(link .. ".md") == 1 then
-			modified_link = modified_link .. ".md"
-		else
-			-- attempt to parse line number
-			local path_and_line_number = vim.split(link, ":")
-			local path = path_and_line_number[1]
-			line_number = path_and_line_number[2]
-			if vim.fn.filereadable(path) == 1 then
-				modified_link = path
-			end
-		end
+	local path_and_line_number = vim.split(link, ":")
+	local path = path_and_line_number[1]
+
+	-- attempt to parse line number, will be nil if index 2 does not exist
+	local line_number = path_and_line_number[2]
+
+	-- attempt to add an extension and open
+	if vim.fn.filereadable(path .. ".md") == 1 then
+		modified_link = path .. ".md"
 	else
-		modified_link = link
+		modified_link = path
 	end
 
 	if modified_link then


### PR DESCRIPTION
This commit simplifies the parsing of local links with line numbers and especially fixes that links without extension do not resolve.

The previous version tried to concatenate modified_link and ".md", but as modified_link is defined as nil this fails. The solution is to concatenate with the variable link. But if a line number is specified this would append ".md" after the line number and the line parsing code is never reached, e. g.:

 - `/path/to/file:23.md`

Therefore the splitting of path and line number is now executed at the beginning of the function. This ensures that the path variable does not contain the line number. For the line_number it is utilized that Lua defaults to a nil value when a non-existing table index is given.