### PR TITLE
Create file.md if file does not exist

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -99,7 +99,7 @@ local function follow_local_link(link)
 	local line_number = path_and_line_number[2]
 
 	-- attempt to add an extension and open
-	if vim.fn.filereadable(path .. ".md") == 1 then
+	if path:sub(-3) ~= ".md" and vim.fn.glob(path) == "" then
 		modified_link = path .. ".md"
 	else
 		modified_link = path


### PR DESCRIPTION
When following a local link, instead of opening `foo.md` if `foo.md` exists, open `foo.md` if `foo` doesn't exist.

I'm using `glob` instead of `filereadable` to allow matching directories, and `path:sub(-3) ~= ".md"` is there to prevent duplicate extensions (ex. `foo.md` being opened as `foo.md.md`).