### PR TITLE
Feat: Resolve man:// links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This neovim plugin allows you to follow markdown links by pressing enter when th
 - text-only reference links (e.g. `[example website]. [example website]: https://example.org`)
 - web links (e.g. `[wikipedia](https://wikipedia.org)`)
 - heading links (e.g. `[chapter 1](#-chapter-1)`
+- man page links (e.g. `[printf library](man://printf(3))`)
 
 Local files are opened in neovim and web links are opened with the default browser. Web links need to start with `https://` or `http://` to be identified properly.
 

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -96,6 +96,9 @@ local function resolve_link(link)
 	elseif link:sub(1, 8) == [[https://]] or link:sub(1, 7) == [[http://]] then
 		link_type = "web"
 		return link, link_type
+	elseif link:sub(1, 6) == [[man://]] then
+		link_type = "man"
+		return link, link_type
 	else
 		link_type = "local"
 		return fn.expand("%:p:h") .. [[/]] .. link, link_type
@@ -151,6 +154,8 @@ function M.follow_link()
 			follow_local_link(resolved_link)
 		elseif link_type == "heading" then
 			follow_heading_link(resolved_link)
+		elseif link_type == "man" then
+			vim.cmd.Man(link_destination:gsub("man://", ""))
 		elseif link_type == "web" then
 			if is_linux then
 				vim.fn.system("xdg-open " .. vim.fn.shellescape(resolved_link))


### PR DESCRIPTION
closes #33 

Neovim provides an integration to read man pages through the man.lua plugin (see $VIMRUNTIME/lua/man.lua). The man page buffers are identified by a leading `man://`. This commit makes use of the high level API from $VIMRUNTIME/plugin/man.lua, as it is properly requires the lowest maintenance effort.