### PR TITLE
feat: add options & cross file navigation with heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This neovim plugin allows you to follow markdown links by pressing enter when th
 - reference links (e.g. `[a file][label]. [label]: ~/folder/a_file`)
 - text-only reference links (e.g. `[example website]. [example website]: https://example.org`)
 - web links (e.g. `[wikipedia](https://wikipedia.org)`)
-- heading links (e.g. `[chapter 1](#-chapter-1)`
+- heading links (e.g. `[chapter 1](#-chapter-1)`)
+- file path with heading link (e.g. `[file.md #chapter 1](file.md#-chapter-1)`)
 
 Local files are opened in neovim and web links are opened with the default browser. Web links need to start with `https://` or `http://` to be identified properly.
 
@@ -93,8 +94,8 @@ end,
 
 ##### Sample code 2 - heading_link
 
-Replace 'and' -> 'and' or '&'
-Replace 'at'  -> 'at'  or '@'
+- Treat 'and' as 'and' or '&'
+- Treat 'at'  as 'at'  or '@'
 
 ```lua
 heading_link = function(link)
@@ -108,7 +109,7 @@ end,
 
 ```
 
-### keys
+### keymaps
 
 ```lua
 keys = {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Local files are opened in neovim and web links are opened with the default brows
 
 This plugin is tested against the latest stable version of neovim. It might work with other versions, but this is not guaranteed.
 
+
 ## Installation
 
 Packer:
@@ -25,12 +26,109 @@ use {
 }
 ```
 
+lazy.nvim:
+```lua
+return {
+   'jghauser/follow-md-links.nvim',
+   dependencies = {
+      'nvim-treesitter/nvim-treesitter',
+   },
+   ft = { 'markdown' },
+   opts = true,
+   cmd = { 'FollowMdLinks' },
+   keys = {},
+}
+```
+or
+
+```lua
+return {
+   'jghauser/follow-md-links.nvim',
+   dependencies = {
+      'nvim-treesitter/nvim-treesitter',
+   },
+   config = function()
+      require('follow-md-links').setup(),
+   end,
+   ft = { 'markdown' },
+   cmd = { 'FollowMdLinks' },
+   keys = {},
+}
+```
+
 As this plugin uses [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to identify links, you will need that plugin, and you will need to make sure you have the treesitter markdown and markdown_inline parsers installed. You can check whether that is the case by looking at the entries in `:checkhealth nvim-treesitter` (there should be a tick in the "H" column). If the markdown parsers are missing, install it with `TSInstall markdown markdown_inline` or by adding them to `ensure_installed` in your nvim-treesitter setup function.
+
 
 ## Configuration
 
-The plugin maps `<cr>` in normal mode to open links in markdown files. You might also want to add the following keymap to easily go back to the previous file with backspace:
+### Default options
+```lua
+opts = {
+   ft = { 'markdown' }, -- limit command to specific filetypes
+   formatter = {
+      heading_link = function(link)
+         link = link:gsub("-", "[- ]*")
+         link = link:gsub("_", "[_ ]*")
+         return link
+      end,
+   },
+},
+```
+
+### formatter
+
+#### heading_link
+
+##### Sample code 1 - heading_link
+
+Sample `heading_link` formatter (Treat '-' and '_' as any symbol character)
+```lua
+heading_link = function(link)
+   local symbols = '[' .. [[ ,.<>/?!;:(){}\[\]@#$%^&*+_="'\\|%%-]] .. ']'
+   link = link:gsub('[-_]', symbols .. '*')
+   link = link .. symbols .. '*$' -- it may have symbol at the end
+   return link
+end,
+```
+
+##### Sample code 2 - heading_link
+
+Replace 'and' -> 'and' or '&'
+Replace 'at'  -> 'at'  or '@'
 
 ```lua
-vim.keymap.set('n', '<bs>', ':edit #<cr>', { silent = true })
+heading_link = function(link)
+   local symbols = '[' .. [[ ,.<>/?!;:(){}\[\]@#$%^&*+_="'\\|%%-]] .. ']'
+   link = link:gsub('[-_]', symbols .. '*')
+   link = link:gsub("and", "\\(&\\|and\\)") -- 'and' --> '&' or 'and'
+   link = link:gsub("at", "\\(@\\|at\\)") -- 'at' --> '@' or 'at'
+   link = link .. symbols .. '*$' -- it may have symbol at the end
+   return link
+end,
+
 ```
+
+### keys
+
+```lua
+keys = {
+   { '<cr>', '<cmd>FollowMdLinks<cr>', desc = 'Follow markdown link', ft = 'markdown' },
+   { '<bs', ':edit #<cr>', desc = 'Back to the previous file', ft = 'markdown'},
+},
+```
+
+## Usage
+
+With your cursor on link and...
+
+Command:
+```vim
+:FollowMdLinks
+```
+Lua:
+```lua
+require('follow-md-links').follow_link()
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ end,
 ```lua
 keys = {
    { '<cr>', '<cmd>FollowMdLinks<cr>', desc = 'Follow markdown link', ft = 'markdown' },
-   { '<bs', ':edit #<cr>', desc = 'Back to the previous file', ft = 'markdown'},
+   { '<bs>', ':edit #<cr>', desc = 'Back to the previous file', ft = 'markdown'},
 },
 ```
 

--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -1,8 +1,0 @@
---
--- FOLLOW MD LINKS
---
-
-local nvim_buf_set_keymap = vim.api.nvim_buf_set_keymap
-
--- follow md links
-nvim_buf_set_keymap(0, 'n', '<cr>', ':lua require("follow-md-links").follow_link()<cr>', {noremap = true, silent = true})

--- a/lua/follow-md-links/commands.lua
+++ b/lua/follow-md-links/commands.lua
@@ -1,13 +1,15 @@
 local M = {}
 
 function M.create_commands()
-   opts = require('follow-md-links.options').get()
+   opts = require("follow-md-links.options").get()
 
    vim.api.nvim_create_autocmd("FileType", {
       pattern = opts.ft,
       callback = function()
          vim.api.nvim_buf_create_user_command(0, "FollowMdLinks", function()
+            print("FollowMdLinks command invoked before")
             require("follow-md-links").follow_link()
+            print("FollowMdLinks command invoked after")
          end, { desc = "Follow markdown link under cursor" })
       end,
    })

--- a/lua/follow-md-links/commands.lua
+++ b/lua/follow-md-links/commands.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+function M.create_commands()
+   opts = require('follow-md-links.options').get()
+
+   vim.api.nvim_create_autocmd("FileType", {
+      pattern = opts.ft,
+      callback = function()
+         vim.api.nvim_buf_create_user_command(0, "FollowMdLinks", function()
+            require("follow-md-links").follow_link()
+         end, { desc = "Follow markdown link under cursor" })
+      end,
+   })
+end
+
+return M

--- a/lua/follow-md-links/core.lua
+++ b/lua/follow-md-links/core.lua
@@ -10,7 +10,7 @@ local query = require("vim.treesitter.query")
 local treesitter = require("vim.treesitter")
 
 function string:startswith(start)
-    return self:sub(1, #start) == start
+   return self:sub(1, #start) == start
 end
 
 local os_name = loop.os_uname().sysname
@@ -19,152 +19,158 @@ local is_macos = os_name == "Darwin"
 local is_linux = os_name == "Linux"
 
 local function get_reference_link_destination(link_label)
-	local language_tree = vim.treesitter.get_parser(0)
-	local syntax_tree = language_tree:parse()
-	local root = syntax_tree[1]:root()
-	local parsed_query = vim.treesitter.query.parse("markdown", [[
+   local language_tree = vim.treesitter.get_parser(0)
+   local syntax_tree = language_tree:parse()
+   local root = syntax_tree[1]:root()
+   local parsed_query = vim.treesitter.query.parse("markdown", [[
   (link_reference_definition
     (link_label) @label (#eq? @label "]] .. link_label .. [[")
     (link_destination) @link_destination)
   ]])
-	-- Problem with handling whitespace in filenames elegently is with this iter_matches
-	for _, captures, _ in parsed_query:iter_matches(root, 0) do
-		local node_text = treesitter.get_node_text(captures[2], 0)
-		-- Kludgy method right now is to require that filenames with spaces are wrapped in <>,
-		-- which are stripped out after the matching is complete
-		return string.gsub(node_text, "[<>]", "")
-		--return treesitter.get_node_text(captures[2], 0)
-	end
+   -- Problem with handling whitespace in filenames elegently is with this iter_matches
+   for _, captures, _ in parsed_query:iter_matches(root, 0) do
+      local node_text = treesitter.get_node_text(captures[2], 0)
+      -- Kludgy method right now is to require that filenames with spaces are wrapped in <>,
+      -- which are stripped out after the matching is complete
+      return string.gsub(node_text, "[<>]", "")
+      --return treesitter.get_node_text(captures[2], 0)
+   end
 end
 
 local function get_link_destination()
-	local node_at_cursor = ts_utils.get_node_at_cursor()
-	local parent_node = node_at_cursor:parent()
-	if not (node_at_cursor and parent_node) then
-		return
-	elseif node_at_cursor:type() == "link_destination" then
-		return vim.split(treesitter.get_node_text(node_at_cursor, 0), "\n")[1]
-	elseif node_at_cursor:type() == "shortcut_link" then
-		local link_text = vim.split(treesitter.get_node_text(node_at_cursor, 0), "\n")[1]
-		return get_reference_link_destination(link_text)
-	elseif node_at_cursor:type() == "link_text" then
-		if node_at_cursor:parent():type() == "shortcut_link" then
-			local link_text = vim.split(treesitter.get_node_text(node_at_cursor:parent(), 0), "\n")[1]
-			return get_reference_link_destination(link_text)
-		end
-		local next_node = ts_utils.get_next_node(node_at_cursor)
-		if next_node:type() == "link_destination" then
-			return vim.split(treesitter.get_node_text(next_node, 0), "\n")[1]
-		elseif next_node:type() == "link_label" then
-			local link_label = vim.split(treesitter.get_node_text(next_node, 0), "\n")[1]
-			return get_reference_link_destination(link_label)
-		end
-	elseif node_at_cursor:type() == "link_reference_definition" or node_at_cursor:type() == "inline_link" then
-		local child_nodes = ts_utils.get_named_children(node_at_cursor)
-		for _, node in pairs(child_nodes) do
-			if node:type() == "link_destination" then
-				return vim.split(treesitter.get_node_text(node, 0), "\n")[1]
-			end
-		end
-	elseif node_at_cursor:type() == "full_reference_link" then
-		local child_nodes = ts_utils.get_named_children(node_at_cursor)
-		for _, node in pairs(child_nodes) do
-			if node:type() == "link_label" then
-				local link_label = vim.split(treesitter.get_node_text(node, 0), "\n")[1]
-				return get_reference_link_destination(link_label)
-			end
-		end
-	elseif node_at_cursor:type() == "link_label" then
-		local link_label = vim.split(treesitter.get_node_text(node_at_cursor, 0), "\n")[1]
-		return get_reference_link_destination(link_label)
-	else
-		return
-	end
+   local node = ts_utils.get_node_at_cursor()
+   if not node then
+      return
+   end
+
+   local candidates = { node }
+   local parent = node:parent()
+   if parent then
+      table.insert(candidates, parent)
+   end
+
+   for _, n in ipairs(candidates) do
+      local t = n:type()
+      if t == "link_destination" then
+         return vim.split(treesitter.get_node_text(n, 0), "\n")[1]
+      elseif t == "shortcut_link" then
+         local text = vim.split(treesitter.get_node_text(n, 0), "\n")[1]
+         return get_reference_link_destination(text)
+      elseif t == "link_text" then
+         local next_node = ts_utils.get_next_node(n)
+         if next_node then
+            local nt = next_node:type()
+            if nt == "link_destination" or nt == "link_label" then
+               local text = vim.split(treesitter.get_node_text(next_node, 0), "\n")[1]
+               if nt == "link_destination" then
+                  return text
+               else
+                  return get_reference_link_destination(text)
+               end
+            end
+         end
+      elseif t == "link_reference_definition" or t == "inline_link" or t == "full_reference_link" then
+         for _, child in ipairs(ts_utils.get_named_children(n)) do
+            if child:type() == "link_destination" then
+               return vim.split(treesitter.get_node_text(child, 0), "\n")[1]
+            elseif child:type() == "link_label" then
+               local label = vim.split(treesitter.get_node_text(child, 0), "\n")[1]
+               return get_reference_link_destination(label)
+            end
+         end
+      elseif t == "link_label" then
+         local label = vim.split(treesitter.get_node_text(n, 0), "\n")[1]
+         return get_reference_link_destination(label)
+      end
+   end
 end
 
 local function resolve_link(link)
-	local link_type
+   local link_type
    local heading
-	if link:sub(1, 8) == [[https://]] or link:sub(1, 7) == [[http://]] then
-		link_type = "web"
-		return link, link_type, nil
-	elseif link:sub(1, 1) == [[#]] then
-		link_type = "heading"
+   if link:sub(1, 8) == [[https://]] or link:sub(1, 7) == [[http://]] then
+      link_type = "web"
+      return link, link_type, nil
+   elseif link:sub(1, 1) == [[#]] then
+      link_type = "heading"
       return link:sub(2), link_type, link:sub(2)
    elseif link:sub(1, 1) == [[/]] then
-		link_type = "local"
-	elseif link:sub(1, 1) == [[~]] then
-		link_type = "local"
-		link = os.getenv("HOME") .. [[/]] .. link:sub(2)
-	else
-		link_type = "local"
-		link = fn.expand("%:p:h") .. [[/]] .. link
-	end
+      link_type = "local"
+   elseif link:sub(1, 1) == [[~]] then
+      link_type = "local"
+      link = os.getenv("HOME") .. [[/]] .. link:sub(2)
+   else
+      link_type = "local"
+      link = fn.expand("%:p:h") .. [[/]] .. link
+   end
    heading = link:match("#(.+)")
    link = link:match("^([^#]+)")
    return link, link_type, heading
 end
 
 local function follow_local_link(link)
-	local modified_link = nil
-	local path_and_line_number = vim.split(link, ":")
-	local path = path_and_line_number[1]
+   local modified_link = nil
+   local path_and_line_number = vim.split(link, ":")
+   local path = path_and_line_number[1]
 
-	-- attempt to parse line number, will be nil if index 2 does not exist
-	local line_number = path_and_line_number[2]
+   -- attempt to parse line number, will be nil if index 2 does not exist
+   local line_number = path_and_line_number[2]
 
-	-- check if it is a directory, and create if true
-	if path:sub(-1) == "/" then
-		path = path:sub(1,-2)
-		if vim.fn.glob(path) == "" then
-			cmd(string.format("%s %s %s", "!mkdir", "-p", fn.fnameescape(path)))
-		end
-	end
+   -- check if it is a directory, and create if true
+   if path:sub(-1) == "/" then
+      path = path:sub(1, -2)
+      if vim.fn.glob(path) == "" then
+         cmd(string.format("%s %s %s", "!mkdir", "-p", fn.fnameescape(path)))
+      end
+   end
 
-	-- attempt to add an extension and open
-	if path:sub(-3) ~= ".md" and vim.fn.glob(path) == "" then
-		modified_link = path .. ".md"
-	else
-		modified_link = path
-	end
+   -- attempt to add an extension and open
+   if path:sub(-3) ~= ".md" and vim.fn.glob(path) == "" then
+      modified_link = path .. ".md"
+   else
+      modified_link = path
+   end
 
-	if modified_link then
-		if line_number then
-			cmd(string.format("%s +%s %s", "e", line_number, fn.fnameescape(modified_link)))
-		else
-			cmd(string.format("%s %s", "e", fn.fnameescape(modified_link)))
-		end
-	end
+   if modified_link then
+      if line_number then
+         cmd(string.format("%s +%s %s", "e", line_number, fn.fnameescape(modified_link)))
+      else
+         cmd(string.format("%s %s", "e", fn.fnameescape(modified_link)))
+      end
+   end
 end
 
 local function follow_heading_link(link)
    local opts = require("follow-md-links.options").get()
    local pattern = opts.formatter.heading_link(link)
-   vim.fn.search('\\c^#\\+\\s*' .. pattern, 'ew')
+   vim.fn.search("\\c^#\\+\\s*" .. pattern, "ew")
 end
 
 local M = {}
 
 function M.follow_link()
-	local link_destination = get_link_destination()
+   local link_destination = get_link_destination()
+   print("get_link_destination() =", vim.inspect(get_link_destination()))
 
-	if link_destination then
-		local resolved_link, link_type, heading = resolve_link(link_destination)
-		if link_type == "local" then
-			follow_local_link(resolved_link)
-         if heading then follow_heading_link(heading) end
-		elseif link_type == "heading" then
-			follow_heading_link(resolved_link)
-		elseif link_type == "web" then
-			if is_linux then
-				vim.fn.system("xdg-open " .. vim.fn.shellescape(resolved_link))
-			elseif is_macos then
-				vim.fn.system("open " .. vim.fn.shellescape(resolved_link))
-			elseif is_windows then
-				vim.fn.system('cmd.exe /c start "" ' .. vim.fn.shellescape(resolved_link))
-			end
-		end
-	end
+   if link_destination then
+      local resolved_link, link_type, heading = resolve_link(link_destination)
+      if link_type == "local" then
+         follow_local_link(resolved_link)
+         if heading then
+            follow_heading_link(heading)
+         end
+      elseif link_type == "heading" then
+         follow_heading_link(resolved_link)
+      elseif link_type == "web" then
+         if is_linux then
+            vim.fn.system("xdg-open " .. vim.fn.shellescape(resolved_link))
+         elseif is_macos then
+            vim.fn.system("open " .. vim.fn.shellescape(resolved_link))
+         elseif is_windows then
+            vim.fn.system('cmd.exe /c start "" ' .. vim.fn.shellescape(resolved_link))
+         end
+      end
+   end
 end
 
 return M

--- a/lua/follow-md-links/init.lua
+++ b/lua/follow-md-links/init.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+local opts_module = require("follow-md-links.options")
+local core_module = require("follow-md-links.core")
+local cmd_module = require('follow-md-links.commands')
+
+function M.setup(user_opts)
+   opts_module.setup(user_opts)
+   cmd_module.create_commands()
+end
+
+M.follow_link = core_module.follow_link
+
+return setmetatable(M, {
+  __call = function(_, ...)
+    M.setup(...)
+  end,
+})

--- a/lua/follow-md-links/options.lua
+++ b/lua/follow-md-links/options.lua
@@ -1,0 +1,24 @@
+local M = {}
+
+M.options = {}
+
+M.defaults = {
+  ft = { 'markdown' },
+  formatter = {
+     heading_link = function(link)
+        link = link:gsub("-", "[- ]*")
+        link = link:gsub("_", "[_ ]*")
+        return link
+     end,
+  },
+}
+
+function M.setup(user_opts)
+   M.options = vim.tbl_deep_extend("force", {}, M.defaults, user_opts or {})
+end
+
+function M.get()
+   return M.options
+end
+
+return M


### PR DESCRIPTION
### Changing
- Add support for `options`
   - Modified file structure
   - `formatter.header_link` is customizable now
   - Modified README.md
- Cross file navigation with heading.
   - Jumps from `[link](filename#sumary)` directly to the corresponding `### sumary` section in the target file.
   
The file structure has been changed significantly.
I hope this change helps future development.

### Bug?
Only `cross file navigation with heading` occasionally failures to jump. Likely caused by TreeSitter parsing issues.