### PR TITLE
Save link position to jumplist

### DIFF
--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -150,6 +150,8 @@ function M.follow_link()
 		if link_type == "local" then
 			follow_local_link(resolved_link)
 		elseif link_type == "heading" then
+			-- Save link position to jumplist
+			cmd("normal! m'")
 			follow_heading_link(resolved_link)
 		elseif link_type == "web" then
 			if is_linux then


### PR DESCRIPTION
Save position of heading link to jumplist, so it can be navigated back using \<C-o\>, for example.

Nvim seems to already save cursor position when jumping between files, so this isn't explicitly needed with link_type == "local".