### PR TITLE
added support for file:// links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This neovim plugin allows you to follow markdown links by pressing enter when th
 - relative file paths (e.g. `[a file](../somefile.txt)`)
 - file paths beginning with `~` (e.g. `[a file](~/folder/a_file)`).
 - file paths with a line number (e.g. `[a file](/home/user/file.md:42)`), this will also place the cursor on the specified line similar to `gF` (see :h gF)
-- externally opened file paths with `file://` followed by a an absolute, relative or a path beginning with `~` (e.g. `[a file](file:///home/yourname/my_doc.pdf)`)
+- externally opened file paths with `file://` followed by an absolute, relative or a path beginning with `~` (e.g. `[a file](file:///home/yourname/my_doc.pdf)`)
 - reference links (e.g. `[a file][label]. [label]: ~/folder/a_file`)
 - text-only reference links (e.g. `[example website]. [example website]: https://example.org`)
 - web links (e.g. `[wikipedia](https://wikipedia.org)`)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This neovim plugin allows you to follow markdown links by pressing enter when th
 - relative file paths (e.g. `[a file](../somefile.txt)`)
 - file paths beginning with `~` (e.g. `[a file](~/folder/a_file)`).
 - file paths with a line number (e.g. `[a file](/home/user/file.md:42)`), this will also place the cursor on the specified line similar to `gF` (see :h gF)
+- externally opened file paths with `file://` followed by a an absolute, relative or a path beginning with `~` (e.g. [a file](file:///home/yourname/my_doc.pdf))
 - reference links (e.g. `[a file][label]. [label]: ~/folder/a_file`)
 - text-only reference links (e.g. `[example website]. [example website]: https://example.org`)
 - web links (e.g. `[wikipedia](https://wikipedia.org)`)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This neovim plugin allows you to follow markdown links by pressing enter when th
 - relative file paths (e.g. `[a file](../somefile.txt)`)
 - file paths beginning with `~` (e.g. `[a file](~/folder/a_file)`).
 - file paths with a line number (e.g. `[a file](/home/user/file.md:42)`), this will also place the cursor on the specified line similar to `gF` (see :h gF)
-- externally opened file paths with `file://` followed by a an absolute, relative or a path beginning with `~` (e.g. [a file](file:///home/yourname/my_doc.pdf))
+- externally opened file paths with `file://` followed by a an absolute, relative or a path beginning with `~` (e.g. `[a file](file:///home/yourname/my_doc.pdf)`)
 - reference links (e.g. `[a file][label]. [label]: ~/folder/a_file`)
 - text-only reference links (e.g. `[example website]. [example website]: https://example.org`)
 - web links (e.g. `[wikipedia](https://wikipedia.org)`)

--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -5,4 +5,5 @@
 local nvim_buf_set_keymap = vim.api.nvim_buf_set_keymap
 
 -- follow md links
-nvim_buf_set_keymap(0, 'n', '<cr>', ':lua require("follow-md-links").follow_link()<cr>', { noremap = true, silent = true })
+nvim_buf_set_keymap(0, 'n', '<cr>', ':lua require("follow-md-links").follow_link(false)<cr>', { noremap = true, silent = true })
+nvim_buf_set_keymap(0, 'n', '<C-o>', ':lua require("follow-md-links").follow_link(true)<cr>', { noremap = true, silent = true })

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -162,6 +162,9 @@ local function resolve_link(link)
   elseif link:sub(1, 1) == [[~]] then
     link_type = "local"
     return os.getenv("HOME") .. [[/]] .. link:sub(2), link_type
+  elseif link:sub(1, 7) == [[file://]] then
+    link_type = "open_local"
+    return (resolve_link(link:sub(8))), link_type
   elseif link:sub(1, 8) == [[https://]] or link:sub(1, 7) == [[http://]] then
     link_type = "web"
     return link, link_type
@@ -227,7 +230,7 @@ function M.follow_link()
       follow_heading_link(resolved_link)
     elseif link_type == "man" then
       vim.cmd.Man(link_destination:gsub("man://", ""))
-    elseif link_type == "web" then
+    elseif link_type == "web" or link_type == "open_local" then
       if is_linux then
         vim.system({ "xdg-open", resolved_link })
       elseif is_macos then

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -223,7 +223,7 @@ function M.follow_link(open)
   if link_destination then
     local resolved_link, link_type = resolve_link(link_destination)
     if open and link_type == "local" then
-        link_type = "xdg-open"
+        link_type = "open_local"
     end
 
     if link_type == "local" then

--- a/lua/follow-md-links.lua
+++ b/lua/follow-md-links.lua
@@ -217,11 +217,15 @@ end
 
 local M = {}
 
-function M.follow_link()
+function M.follow_link(open)
   local link_destination = get_link_destination()
 
   if link_destination then
     local resolved_link, link_type = resolve_link(link_destination)
+    if open and link_type == "local" then
+        link_type = "xdg-open"
+    end
+
     if link_type == "local" then
       follow_local_link(resolved_link)
     elseif link_type == "heading" then


### PR DESCRIPTION
The `file://` links opens a file with `xdg-open` or OS equivalent so non-text files such as PDF or image files can be opened using the system default program. Supports the following format:
- The format that works in your browser: `file:///home/yourname/document.pdf`
- The `~` format, doesn't work on browser, but is a natural extension to the link syntax: `file://~/document.pdf`
- Relative paths: `file://./document.pdf`

Relative paths is resolved using the resolver for `local`, and files are opened using the opener for `web`.